### PR TITLE
Add a `AbstractChainedJob::process_items` method to give more control over processing items

### DIFF
--- a/src/AbstractChainedJob.php
+++ b/src/AbstractChainedJob.php
@@ -138,11 +138,7 @@ abstract class AbstractChainedJob extends AbstractJob implements ChainedJobInter
 			// No more items to process so end the job chain
 			$this->queue_end( $args );
 		} else {
-			$items = $this->filter_items_before_processing( $items );
-
-			foreach ( $items as $item ) {
-				$this->process_item( $item, $args );
-			}
+			$this->process_items( $items, $args );
 
 			// If there were items, queue another batch.
 			$this->queue_batch( $batch_number + 1, $args );
@@ -150,16 +146,19 @@ abstract class AbstractChainedJob extends AbstractJob implements ChainedJobInter
 	}
 
 	/**
-	 * Filter-like function that runs before items in a batch are processed.
+	 * Processes a batch of items.
 	 *
-	 * This could be useful if the results from the initial batch query need to be filtered in an additional query.
+	 * @since 1.1.0
 	 *
-	 * @param array $items
+	 * @param array $items The items of the current batch.
+	 * @param array $args  The args for the job.
 	 *
-	 * @return array
+	 * @throws Exception On error. The failure will be logged by Action Scheduler and the job chain will stop.
 	 */
-	protected function filter_items_before_processing( array $items ): array {
-		return $items;
+	protected function process_items( array $items, array $args ) {
+		foreach ( $items as $item ) {
+			$this->process_item( $item, $args );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Prompted by discussion: https://github.com/woocommerce/facebook-for-woocommerce/pull/1924/files#r633891360

This PR evolves the `filter_items_before_processing` into a more flexible `process_items` method. This method could be overwritten in a child job class letting it completely take over how the whole batch of items is processed.

This is a breaking change (although it doesn't have to be) since this project is only being used by [Facebook for WooCommerce](https://github.com/woocommerce/facebook-for-woocommerce). I feel like we should be somewhat flexible with making changes until we decide to use it in a second project.