### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Removed `...AbstractChainedJob::filter_items_before_processing` method ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))
+- Removed `...AbstractChainedJob::filter_items_before_processing` method in favor of the more flexible `process_items` method ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))
 
 ### New Feature
-- Added `...AbstractChainedJob::process_items` method ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))
+- Added `...AbstractChainedJob::process_items` method to give jobs more control over how the whole batch is processed ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- For now we follow Gutenberg's package changelog format https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
-## 1.1.0 (2021-05-19)
+## 2.0.0 (2021-05-19)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+<!-- For now we follow Gutenberg's package changelog format https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## 1.1.0 (2021-05-19)
+
+### Breaking Changes
+
+- Removed `...AbstractChainedJob::filter_items_before_processing` method ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))
+
+### New Feature
+- Added `...AbstractChainedJob::process_items` method ([#2](https://github.com/woocommerce/action-scheduler-job-framework/pull/2))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 - PHP 7.0+
 
-## Breaking changes
+## Versioning & breaking changes
+
+This package follows [Semver](https://semver.org/) for versioning.
 
 This framework may receive breaking changes at the moment while it is only used in the [Facebook for WooCommerce](https://github.com/woocommerce/facebook-for-woocommerce) plugin.
 However, once we use it in another plugin we will need to reject all breaking changes.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 - PHP 7.0+
 
+## Breaking changes
+
+This framework may receive breaking changes at the moment while it is only used in the [Facebook for WooCommerce](https://github.com/woocommerce/facebook-for-woocommerce) plugin.
+However, once we use it in another plugin we will need to reject all breaking changes.
+
 ## Installation
 
 The framework should be installed via [Composer](https://getcomposer.org/). 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Requirements
 
 - PHP 7.0+
+- [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) - Required to ensure the latest version of the framework is used in case multiple plugins have it as a dependency
+
 
 ## Versioning & breaking changes
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "woocommerce/action-scheduler-job-framework",
     "description": "A job framework for Action Scheduler (actionscheduler.org)",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "type": "library",
     "license": "GNU",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "woocommerce/action-scheduler-job-framework",
     "description": "A job framework for Action Scheduler (actionscheduler.org)",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "type": "library",
     "license": "GNU",
     "require": {


### PR DESCRIPTION
Releases a new version of the framework with a tiny change to help https://github.com/woocommerce/facebook-for-woocommerce/pull/1924

- This PR also adds a changelog. I chose the Gutenberg format so we can have issue links and formatting.
- I also added a note about breaking changes
- See released PR #2 

Thoughts and feedback welcome. I'm somewhat rushing this out so we can keep FB feed work moving.